### PR TITLE
make options go up so they dont overlap the input-text containing the…

### DIFF
--- a/vendor/assets/javascripts/select2-full.js
+++ b/vendor/assets/javascripts/select2-full.js
@@ -4267,7 +4267,8 @@ S2.define('select2/dropdown/attachBody',[
 
     var css = {
       left: offset.left,
-      top: container.bottom
+      top: container.bottom,
+      padding: '0 0 20px 0'
     };
 
     // Determine what the parent element is to use for calciulating the offset


### PR DESCRIPTION
Jira ticket: https://onedoor.atlassian.net/browse/SUP-642

The click on 'x' is also hitting options bellow, so options must be separated from the text-input bar